### PR TITLE
Mount all js source except node_modules

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -75,24 +75,6 @@ RUN ../bridge-server-venv/bin/pip3.6 install kombu==4.1
 # https://github.com/OriginProtocol/bridge-server/issues/74
 RUN sed -i '24s/.*/    return True\n    """/' /opt/bridge-server/bridge-server-venv/lib/python3.6/site-packages/ipfsapi/client.py
 
-# js - install node modules
-RUN mkdir /opt/origin-js
-WORKDIR /opt/origin-js
-RUN git clone https://github.com/OriginProtocol/origin-js.git temp-source
-WORKDIR /opt/origin-js/temp-source
-RUN git checkout develop
-RUN npm run install:dev
-RUN cp -r node_modules /opt/origin-js/node_modules
-
-# dapp - install node modules
-RUN mkdir /opt/origin-dapp
-WORKDIR /opt/origin-dapp
-RUN git clone https://github.com/OriginProtocol/demo-dapp.git temp-source
-WORKDIR /opt/origin-dapp/temp-source
-RUN git checkout develop
-RUN npm run install:dev
-RUN mv node_modules /opt/origin-dapp/node_modules
-
 # Copy start scripts for js and dapp
 COPY files/scripts/start-js.sh /opt/origin-js/scripts/start-js.sh
 COPY files/scripts/start-dapp.sh /opt/origin-dapp/scripts/start-dapp.sh

--- a/container/files/scripts/start-dapp.sh
+++ b/container/files/scripts/start-dapp.sh
@@ -1,8 +1,3 @@
 cd /opt/origin-dapp/source
-
-# update symlink to origin
-rm /usr/lib/node_modules/origin
-ln -s /opt/origin-js/source /usr/lib/node_modules/origin
-
-cp -r /opt/origin-dapp/node_modules node_modules
+npm run install:dev
 npm start

--- a/container/files/scripts/start-js.sh
+++ b/container/files/scripts/start-js.sh
@@ -1,3 +1,3 @@
 cd /opt/origin-js/source
-cp -r /opt/origin-js/node_modules node_modules
+npm run install:dev
 npm start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,9 @@ services:
     volumes:
       - ./bridge:/opt/bridge-server/source
       - ./js:/opt/origin-js/source
+      - /opt/origin-js/source/node_modules
       - ./dapp:/opt/origin-dapp/source
+      - /opt/origin-dapp/source/node_modules
     ports:
       - "3000:3000"
       - "4000:4000"


### PR DESCRIPTION
Now we don't have to do our weird hack of copying node_modules folders around. Also means we mount a *lot* less code - I think this fixes the performance issues we've been having. (node_modules is a tremendous directory in terms of number of subdirectories and files).

The node_modules directory ignore is a nice little trick I found on Stack Overflow. So helpful! https://stackoverflow.com/a/37898591/4376543