### PR TITLE
Symlink contracts from origin-js to bridge server

### DIFF
--- a/container/files/config/bridge_server_dev.env
+++ b/container/files/config/bridge_server_dev.env
@@ -26,3 +26,5 @@ TWILIO_AUTH_TOKEN=xxxxxx
 TWILIO_NUMBER=xxxxxxxxxx
 TWITTER_CONSUMER_KEY=xxxxxxxxxxxx
 TWITTER_CONSUMER_SECRET=xxxxxxxxxxx
+
+CONTRACT_DIR=contracts_dev

--- a/container/files/scripts/start-bridge-server.sh
+++ b/container/files/scripts/start-bridge-server.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Create symlink from origin-js contract ABIs to bridge server ABIs
+ln -sfn /opt/origin-js/source/contracts/build/contracts /opt/bridge-server/source/contracts_dev
+
 cd $BRIDGE_SERVER_PATH
 source $BRIDGE_SERVER_ENV_PATH/bin/activate
 main.py flask db migrate


### PR DESCRIPTION
This way, any updates to the contracts in origin-js will automatically update the bridge server. Handy for development.

Works with https://github.com/OriginProtocol/bridge-server/pull/92

Fixes #10