### PR TITLE
Implement startup dependencies for bridge and dapp

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -75,6 +75,10 @@ RUN ../origin-bridge-venv/bin/pip3.6 install kombu==4.1
 # https://github.com/OriginProtocol/origin-bridge/issues/74
 RUN sed -i '24s/.*/    return True\n    """/' /opt/origin-bridge/origin-bridge-venv/lib/python3.6/site-packages/ipfsapi/client.py
 
+# Copy wait for script for startup dependencies
+COPY files/scripts/wait-for.sh /usr/local/bin
+RUN chmod +x /usr/local/bin/wait-for.sh
+
 # Copy start scripts for js and dapp
 COPY files/scripts/start-js.sh /opt/origin-js/scripts/start-js.sh
 COPY files/scripts/start-dapp.sh /opt/origin-dapp/scripts/start-dapp.sh

--- a/container/files/scripts/start-bridge.sh
+++ b/container/files/scripts/start-bridge.sh
@@ -6,4 +6,5 @@ ln -sfn /opt/origin-js/source/contracts/build/contracts /opt/origin-bridge/sourc
 cd $BRIDGE_SERVER_PATH
 source $BRIDGE_SERVER_ENV_PATH/bin/activate
 main.py flask db migrate
-python main.py
+
+wait-for.sh -t 0 -q localhost:8545 -- wait-for.sh -t 0 -q localhost:8080 -- echo 'origin-js is available, starting origin-bridge...' && python main.py

--- a/container/files/scripts/start-celery.sh
+++ b/container/files/scripts/start-celery.sh
@@ -2,4 +2,5 @@
 
 cd $BRIDGE_SERVER_PATH
 source $BRIDGE_SERVER_ENV_PATH/bin/activate
-celery -A util.tasks worker -c=1 -E -B -l debug
+
+wait-for.sh -t 0 -q localhost:8545 -- wait-for.sh -t 0 -q localhost:8080 -- echo 'origin-js is available, starting origin-bridge celery...' && celery -A util.tasks worker -c=1 -E -B -l debug

--- a/container/files/scripts/start-dapp.sh
+++ b/container/files/scripts/start-dapp.sh
@@ -1,3 +1,4 @@
 cd /opt/origin-dapp/source
-npm run install:dev
-npm start
+
+# Cant do install until origin-js is available due to linking
+wait-for.sh -t 0 -q localhost:5000 -- echo 'origin-bridge is available, starting origin-dapp...' && npm run install:dev && npm start

--- a/container/files/scripts/wait-for.sh
+++ b/container/files/scripts/wait-for.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        if [[ $ISBUSY -eq 1 ]]; then
+            nc -z $HOST $PORT
+            result=$?
+        else
+            (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+            result=$?
+        fi
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+# check to see if timeout is from busybox?
+# check to see if timeout is from busybox?
+TIMEOUT_PATH=$(realpath $(which timeout))
+if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
+        ISBUSY=1
+        BUSYTIMEFLAG="-t"
+else
+        ISBUSY=0
+        BUSYTIMEFLAG=""
+fi
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec "${CLI[@]}"
+else
+    exit $RESULT
+fi
+


### PR DESCRIPTION
Resolves issue #21 and issue #17.

This change means:

- origin-bridge and origin-bridge celery wait for origin-js
- origin-dapp waits for origin-bridge

More dependencies could be added, like making origin-bridge wait for postgresql and redis. But in practice origin-js takes way longer than either of those services, so I left them out for simplicity.
