### PR TITLE
Box was not being configured properly.

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,30 +1,15 @@
-# Clone bridge server source
-git clone https://github.com/OriginProtocol/origin-bridge.git
+#!/bin/bash
+set -e # Exit shell script on an error
+set -x # Echo shell commands as they run
 
-# Checkout bridge server develop branch
-cd origin-bridge
-git checkout develop
-cd ..
+# Clone bridge server, origin-js, and dapp sources
+git clone -b develop https://github.com/OriginProtocol/origin-bridge.git
+git clone -b develop https://github.com/OriginProtocol/origin-js.git
+git clone -b develop https://github.com/OriginProtocol/origin-dapp.git
 
-# Clone js source
-git clone https://github.com/OriginProtocol/origin-js.git
-
-# Checkout js develop branch
-cd origin-js
-git checkout develop
-cd ..
-
-# Clone dapp source
-git clone https://github.com/OriginProtocol/origin-dapp.git
-
-# Checkout dapp develop branch
-cd origin-dapp
-git checkout develop
-cd ..
-
-# Copy .env files to source
-cp ./container/files/config/bridge_dev.env ./bridge/.env
-cp ./container/files/config/dapp_dev.env ./dapp/.env
+# Copy .env files to configure apps for the origin-box 
+cp ./container/files/config/bridge_dev.env ./origin-bridge/.env
+cp ./container/files/config/dapp_dev.env ./origin-dapp/.env
 
 # Build bridge server image
 docker build ./container -t origin-image


### PR DESCRIPTION
Env files were being copied to a non-existent directory, so the copy command was failing and the bridge and dapp were not being configured. Updated the destination for these.

The setup shell script will now fail if any command fails. This should prevent this kind of error in the future.

Git commands have been tightened.