### PR TITLE
Add elasticsearch image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ To remove all docker containers and volumes and start from scratch:
 3. `docker volume prune`
 4. `./install.sh -e origin`
 
+### Elasticsearch fails to start with virtual memory error
+
+The development stack includes an Elasticsearch container which may require an increase in the mmap counts for your OS. On Linux this can be achieved by running:
+
+	sysctl -w vm.max_map_count=262144
+
+For more information, see this [link.](https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html)
+
 ### Port errors
 
 The environment requires a number of ports to be free on your machine (3000, 5000, 5002, 8080, 8081 and 8545). If one of these ports isn't available spinning up the development environment may fail.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,17 +34,21 @@ services:
     networks:
       - origin-develop
 
-# elasticsearch:
-#   image: docker.elastic.co/elasticsearch/elasticsearch:6.3.1
-#   container_name: elasticsearch
-#   ports:
-#     - "9200:9200"
-#   environment:
-#     ES_JAVA_OPTS: "-Xmx256m -Xms256m"
-#   ports:
-#     - "9200:9200"
-#   networks:
-#     - origin-develop
+  elasticsearch:
+    container_name: elasticsearch
+    image: elasticsearch
+    build:
+      context: .
+      dockerfile: dockerfiles/elasticsearch
+    ports:
+      - "9200:9200"
+    environment:
+      network.bind_host: 0
+      ES_JAVA_OPTS: "-Xmx256m -Xms256m"
+    ports:
+      - "9200:9200"
+    networks:
+      - origin-develop
 
   origin-js:
     container_name: origin-js

--- a/dockerfiles/elasticsearch
+++ b/dockerfiles/elasticsearch
@@ -1,0 +1,15 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.3.1
+
+USER elasticsearch
+
+# Make wait-for.sh available
+COPY ./scripts/wait-for.sh /usr/local/bin
+
+# Create the "origin" index by starting elasticsearch, sending the index creation command, then taking down elasticsearch.
+RUN elasticsearch -p /tmp/espid & echo 'Waiting for elastic...'; \
+    wait-for.sh -t 0 -q localhost:9200 -- echo 'Elastic ready.'; \
+    /usr/bin/curl -X PUT 'localhost:9200/origin' -H 'Content-Type: application/json' -d'{}'; \
+    kill `cat /tmp/espid`; \
+    wait `cat /tmp/espid`; \
+    echo 'Index created successfully. Exiting.'; \
+    exit 0


### PR DESCRIPTION
Adding the elasticsearch container now that we are starting to work on the indexer.
It customizes the stock elasticsearch 6.3.1 image for the purpose of creating the "origin" index. In the future we may need further customisation for creating mappings, etc...