### PR TITLE
Clone from stable branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Origin Box has several intended use cases:
 
 ![install.sh](https://raw.githubusercontent.com/OriginProtocol/origin-box/master/screenshot.png)
 
-The install script will clone the origin repositories into subdirectories and checkout the laatest stable release tags. You can then `cd` into any one of them and run `git` commands as you would in any other cloned repository. For example, if you would like to run the bleeding-edge versions that are under active development, you would need to checkout the master branch in each repository:
+The install script will clone the origin repositories into subdirectories and checkout the stable branches. You can then `cd` into any one of them and run `git` commands as you would in any other cloned repository. For example, if you would like to run the bleeding-edge versions that are under active development, you would need to checkout the master branch in each repository:
 
 ```
 # to explore active development

--- a/README.md
+++ b/README.md
@@ -37,9 +37,26 @@ Origin Box has several intended use cases:
 
 2. Run `./install.sh -e origin` for the standard stack, or `./install.sh -e origin-website` for the website stack.
 
-The install script will clone the origin repositories into subdirectories and checkout the develop branch. You can then develop and use them as normal git repositories. If the install script doesn't complete the most likely reason is you don't have the [required ports](#port-errors) open.
-
 ![install.sh](https://raw.githubusercontent.com/OriginProtocol/origin-box/master/screenshot.png)
+
+The install script will clone the origin repositories into subdirectories and checkout the laatest stable release tags. You can then `cd` into any one of them and run `git` commands as you would in any other cloned repository. For example, if you would like to run the bleeding-edge versions that are under active development, you would need to checkout the master branch in each repository:
+
+```
+# to explore active development
+cd origin-dapp
+git checkout --track origin/master
+cd ../origin-js
+git checkout --track origin/master
+cd ../origin-bridge
+git checkout --track origin/master
+```
+or
+```
+cd origin-website
+git checkout --track origin/master
+```
+
+If the install script doesn't complete the most likely reason is you don't have the [required ports](#port-errors) open.
 
 ## Configuration
 

--- a/install.sh
+++ b/install.sh
@@ -76,13 +76,13 @@ function install_origin_environment() {
 	print_origin_start
 
 	run_step "Cloning origin-js" \
-		git clone git@github.com:OriginProtocol/origin-js.git --branch develop || true
+		git clone git@github.com:OriginProtocol/origin-js.git --branch v0.7.1 || true
 
 	run_step "Cloning origin-bridge" \
-		git clone git@github.com:OriginProtocol/origin-bridge.git --branch develop || true
+		git clone git@github.com:OriginProtocol/origin-bridge.git --branch v0.7.1 || true
 
 	run_step "Cloning origin-dapp" \
-		git clone git@github.com:OriginProtocol/origin-dapp.git --branch develop || true
+		git clone git@github.com:OriginProtocol/origin-dapp.git --branch v0.7.1 || true
 
 	run_step "Building containers" \
 		docker-compose build --no-cache
@@ -104,7 +104,7 @@ function install_website_environment() {
 	print_website_start
 
 	run_step "Cloning origin-website" \
-		git clone git@github.com:OriginProtocol/origin-website.git --branch develop || true
+		git clone git@github.com:OriginProtocol/origin-website.git --branch v1.11.1 || true
 
 	run_step "Building containers" \
 	  docker-compose -f docker-compose-web.yml build --no-cache

--- a/install.sh
+++ b/install.sh
@@ -76,13 +76,13 @@ function install_origin_environment() {
 	print_origin_start
 
 	run_step "Cloning origin-js" \
-		git clone git@github.com:OriginProtocol/origin-js.git --branch v0.7.1 || true
+		git clone git@github.com:OriginProtocol/origin-js.git --branch stable || true
 
 	run_step "Cloning origin-bridge" \
-		git clone git@github.com:OriginProtocol/origin-bridge.git --branch v0.7.1 || true
+		git clone git@github.com:OriginProtocol/origin-bridge.git --branch stable || true
 
 	run_step "Cloning origin-dapp" \
-		git clone git@github.com:OriginProtocol/origin-dapp.git --branch v0.7.1 || true
+		git clone git@github.com:OriginProtocol/origin-dapp.git --branch stable || true
 
 	run_step "Building containers" \
 		docker-compose build --no-cache
@@ -104,7 +104,7 @@ function install_website_environment() {
 	print_website_start
 
 	run_step "Cloning origin-website" \
-		git clone git@github.com:OriginProtocol/origin-website.git --branch v1.11.1 || true
+		git clone git@github.com:OriginProtocol/origin-website.git --branch stable || true
 
 	run_step "Building containers" \
 	  docker-compose -f docker-compose-web.yml build --no-cache


### PR DESCRIPTION
This updates the installation script to use the tagged release versions as proposed in https://github.com/OriginProtocol/origin-devops/issues/16#issue-346262613. There is probably a case to be made that we should have the tags on a `stable` branch in order to avoid producing this experience:

```
You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>
```

I hate to keep a redundant `stable` branch lying around that simply reflects the latest tag. But it might also make sense to have a `stable` branch as the base and target for hotfixes. Then we're basically doing a modified [GitFlow](https://nvie.com/posts/a-successful-git-branching-model/) with just the branches renamed from `develop` & `master` to `master` & `stable`.