### PR TITLE
Remove redis and celery

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,15 +24,6 @@ services:
     networks:
       - origin-develop
 
-  redis:
-    container_name: redis
-    restart: always
-    image: redis
-    sysctls:
-      - net.core.somaxconn=4096
-    networks:
-      - origin-develop
-
   elasticsearch:
     container_name: elasticsearch
     image: elasticsearch
@@ -101,49 +92,14 @@ services:
       # Set the envfile from the local envfile
       - ./envfiles/origin-bridge.env:/app/.env
       - flask_session:/app/flask_session
-      # Contracts volume mounted so origin-bridge uses the contracts compiled
-      # by origin-js
-      - contracts:/app/contracts
     depends_on:
       - postgres
-      - redis
-      - origin-js
-      - orbit-db
     ports:
       - "5000:5000"
     environment:
       - FLASK_APP=/app/main.py
       - FLASK_DEBUG=1
-    command:
-      # Waits for origin-js to start, 8080 is the IPFS server which starts
-      # after the contracts have been compiled
-      >
-      /bin/bash -c "wait-for.sh -t 0 -q origin-js:8080 --
-      echo 'origin-js is available, starting origin-bridge...' &&
-      flask run --host=0.0.0.0"
-    networks:
-      - origin-develop
-
-  origin-bridge-celery:
-    container_name: origin-bridge-celery
-    image: origin-bridge
-    user: nobody
-    volumes:
-      - ./origin-bridge:/app
-      # Set the envfile from the local envfile
-      - ./envfiles/origin-bridge.env:/app/.env
-      - contracts:/app/contracts
-    depends_on:
-      - origin-bridge
-    command:
-      # Celery beat is currently disabled because of incompatibilities between
-      # the develop branches of origin-bridge and origin-js, add " -B" to the
-      # celery command to enable
-      >
-      /bin/bash -c "wait-for.sh -t 0 -q origin-bridge:5000 --
-      echo 'origin-bridge is available, starting origin-bridge celery...' &&
-      watchmedo auto-restart -d . -p '*.py' -i '*.pyc' --recursive --
-      celery -A util.tasks worker -l info -c=1 -E"
+    command: flask run --host=0.0.0.0
     networks:
       - origin-develop
 

--- a/dockerfiles/origin-bridge
+++ b/dockerfiles/origin-bridge
@@ -10,5 +10,5 @@ RUN pip install -r requirements.txt
 # Make wait-for.sh available
 COPY ./scripts/wait-for.sh /usr/local/bin
 
-# Install watchdog for celery auto restart on code changes
+# Install watchdog for auto restart on code changes
 RUN pip install watchdog

--- a/dockerfiles/origin-website
+++ b/dockerfiles/origin-website
@@ -4,7 +4,7 @@ FROM python:2.7
 WORKDIR /app
 COPY ./origin-website/requirements.txt /app
 RUN pip install -r requirements.txt
-# Install watchdog for celery auto restart on code changes
+# Install watchdog for auto restart on code changes
 RUN pip install watchdog
 # Reinstall flask-recaptcha in a different due to volume overwrite
 RUN pip install -e git://github.com/OriginProtocol/flask-recaptcha.git@master#egg=flask_recaptcha --src /tmp

--- a/install.sh
+++ b/install.sh
@@ -90,9 +90,6 @@ function install_origin_environment() {
 	run_step "Bringing up stack" \
 		docker-compose up -d
 
-	run_step "Waiting for contracts" \
-		docker-compose exec origin-bridge wait-for.sh -t 0 -q origin-js:8080
-
 	run_step "Configuring database" \
 		docker-compose exec origin-bridge flask db upgrade
 


### PR DESCRIPTION
The event listener in bridge is being replaced by a Node.js implementation.
So we no longer need the bridge server to use celery/redis.

I'll clean up the code on the bridge server side as a separate PR.