### PR TITLE
Don't rely on node_modules/.bin symlink for webpack-dev-server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,6 +141,6 @@ services:
       cp /tmp/.env.new /app/.env &&
       npm install --quiet --no-progress &&
       npm link origin &&
-      node_modules/.bin/webpack-dev-server --host 0.0.0.0 --watch-poll 500"
+      node node_modules/webpack-dev-server/bin/webpack-dev-server.js --host 0.0.0.0 --watch-poll 500"
     networks:
       - origin-develop


### PR DESCRIPTION
For some reason the install of `webpack-dev-server` was not adding a symlink to `node_modules/.bin` in some situations. Instead of relying on that symlink being created we'll just call it directly.

Thanks @mek32390 for taking the time to zip up your `origin-box` folder and send it to me when I couldn't reproduce this on my own setup.