### PR TITLE
📙 Discovery - Add local discovery server env variables

### DIFF
--- a/envfiles/origin-dapp.env
+++ b/envfiles/origin-dapp.env
@@ -8,6 +8,10 @@ BRIDGE_SERVER_DOMAIN=localhost:5000
 
 PROVIDER_URL=http://localhost:8545
 
+# Discovery Server
+DISCOVERY_SERVER=http://localhost
+DISCOVERY_SERVER_PORT=4000
+
 # IPFS API settings
 IPFS_DOMAIN=localhost
 IPFS_API_PORT=5002

--- a/envfiles/origin-dapp.env
+++ b/envfiles/origin-dapp.env
@@ -9,8 +9,7 @@ BRIDGE_SERVER_DOMAIN=localhost:5000
 PROVIDER_URL=http://localhost:8545
 
 # Discovery Server
-DISCOVERY_SERVER=http://localhost
-DISCOVERY_SERVER_PORT=4000
+DISCOVERY_SERVER_URL=http://localhost:4000
 
 # IPFS API settings
 IPFS_DOMAIN=localhost


### PR DESCRIPTION
Discovery - Add local discovery server env variables

Auto-configure the dapp to use the local discovery server when running in the box.