### PR TITLE
Add faucet deployment

### DIFF
--- a/deployment/dockerfiles/dev/origin-faucet
+++ b/deployment/dockerfiles/dev/origin-faucet
@@ -1,0 +1,16 @@
+FROM node:9
+WORKDIR /app
+
+# Clone origin-js from master (dev) branch
+RUN git clone https://github.com/OriginProtocol/origin-js.git --branch master /app
+
+# Build origin-js so contract ABI is available
+RUN npm install --quiet --no-progress
+RUN npm run build
+
+WORKDIR /app/token
+# Install dependencies for origin-faucet
+RUN npm install --quiet --no-progress
+
+# Configure for Origin network
+CMD ["node", "faucet/app.js", "--network_ids=2222"]

--- a/deployment/dockerfiles/staging/origin-faucet
+++ b/deployment/dockerfiles/staging/origin-faucet
@@ -1,0 +1,16 @@
+FROM node:9
+WORKDIR /app
+
+# Clone origin-js from staging branch
+RUN git clone https://github.com/OriginProtocol/origin-js.git --branch staging /app
+
+# Build origin-js so contract ABI is available
+RUN npm install --quiet --no-progress
+RUN npm run build
+
+WORKDIR /app/token
+# Install dependencies for origin-faucet
+RUN npm install --quiet --no-progress
+
+# Configure for Rinekby
+CMD ["node", "faucet/app.js", "--network_ids=4"]

--- a/deployment/kubernetes/chart/templates/_helpers.tpl
+++ b/deployment/kubernetes/chart/templates/_helpers.tpl
@@ -16,12 +16,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "bridge.fullname" -}}
+{{- printf "%s-%s" .Release.Name "bridge" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "dapp.fullname" -}}
 {{- printf "%s-%s" .Release.Name "dapp" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "bridge.fullname" -}}
-{{- printf "%s-%s" .Release.Name "bridge" | trunc 63 | trimSuffix "-" -}}
+{{- define "ethereum.fullname" -}}
+{{- printf "%s-%s" .Release.Name "ethereum" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "faucet.fullname" -}}
+{{- printf "%s-%s" .Release.Name "faucet" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "ipfs.fullname" -}}
@@ -30,8 +38,4 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this
 
 {{- define "messaging.fullname" -}}
 {{- printf "%s-%s" .Release.Name "messaging" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "ethereum.fullname" -}}
-{{- printf "%s-%s" .Release.Name "ethereum" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/deployment/kubernetes/chart/templates/faucet.deployment.yaml
+++ b/deployment/kubernetes/chart/templates/faucet.deployment.yaml
@@ -1,0 +1,35 @@
+{{ if ne .Release.Namespace "prod" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "faucet.fullname" . }}
+  labels:
+    app: {{ template "faucet.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ default 2 .Values.faucetReplicas }}
+  selector:
+    matchLabels:
+      app: {{ template "faucet.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "faucet.fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+    spec:
+      containers:
+      - name: origin-faucet
+        image: "{{ .Values.containerRegistry }}/{{ .Release.Namespace }}/{{ .Values.faucetImage }}:{{ .Values.faucetImageTag }}"
+        ports:
+        - containerPort: 5000
+        env:
+          {{- if eq .Release.Namespace "dev" }}
+        - name: ORIGIN_MNEMONIC
+          {{- else if eq .Release.Namespace "staging" }}
+        - name: RINKEBY_MNEMONIC
+          {{- end }}
+          value: {{ .Values.faucetMnemonic }}
+{{ end }}

--- a/deployment/kubernetes/chart/templates/faucet.ingress.yaml
+++ b/deployment/kubernetes/chart/templates/faucet.ingress.yaml
@@ -1,0 +1,29 @@
+{{ if ne .Release.Namespace "prod" }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "faucet.fullname" . }}
+  labels:
+    app: {{ template "faucet.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+spec:
+  tls:
+    - secretName: faucet.{{ .Release.Namespace }}.originprotocol.com
+      hosts:
+        - faucet.{{ .Release.Namespace }}.originprotocol.com
+  rules:
+  - host: faucet.{{ .Release.Namespace }}.originprotocol.com
+    http:
+      paths:
+        - path: /
+          backend:
+            serviceName: {{ template "faucet.fullname" . }}
+            servicePort: 5000
+{{ end }}

--- a/deployment/kubernetes/chart/templates/faucet.service.yaml
+++ b/deployment/kubernetes/chart/templates/faucet.service.yaml
@@ -1,0 +1,18 @@
+{{ if ne .Release.Namespace "prod" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "faucet.fullname" . }}
+  labels:
+    app: {{ template "faucet.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: NodePort
+  selector:
+    app: {{ template "faucet.fullname" . }}
+  ports:
+  - name: http
+    port: 5000
+{{ end }}

--- a/deployment/kubernetes/chart/values.yaml
+++ b/deployment/kubernetes/chart/values.yaml
@@ -12,6 +12,10 @@ dappImage: origin-dapp
 dappImageTag: latest
 dappReplicas: 2
 
+# origin-faucet
+faucetImage: origin-faucet
+faucetImageTag: latest
+
 # ipfs
 ipfsImage: ipfs/go-ipfs
 ipfsImageTag: master

--- a/deployment/kubernetes/values/values-staging.yaml
+++ b/deployment/kubernetes/values/values-staging.yaml
@@ -1,3 +1,1 @@
 dappImageTag: 'b9c69cb'
-
-faucetImageTag: '28438d2'

--- a/deployment/kubernetes/values/values-staging.yaml
+++ b/deployment/kubernetes/values/values-staging.yaml
@@ -1,0 +1,3 @@
+dappImageTag: 'b9c69cb'
+
+faucetImageTag: '28438d2'

--- a/deployment/kubernetes/values/values-staging.yaml
+++ b/deployment/kubernetes/values/values-staging.yaml
@@ -1,1 +1,0 @@
-dappImageTag: 'b9c69cb'


### PR DESCRIPTION
This adds the deployment containers and Kubernetes config for the containers.

I know you were interested in seeing what it looks like to add something to the Kubernetes deployment @cuongdo. Might be worth checking it out too @franckc, @wanderingstan and anyone else who is interested.

The Kubernetes components here are:

- An [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) which allows the outside world access to the service. It uses letsencrypt to transparently handle SSL certificates. The ingress points at the service.
- A [service](https://kubernetes.io/docs/concepts/services-networking/service/) which exposes a port on the nodes that the containers are running on.
- A [deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) which is responsible for maintaining the pods that the containers are running in. The deployment specifies 2 replicas which allows for rolling updates. It all specifies the container to be used and the environment variables to set.

The Kubernetes stuff is using [Helm](https://www.helm.sh/) which allows for the templating and flow control (stuff in `{{ }}`).

