### PR TITLE
Use $BRANCH for get git short hash

### DIFF
--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -33,7 +33,7 @@ function build_and_push_container() {
   echo -e "Deployed container tag is \033[94m${DEPLOYED_TAG}\033[0m"
 
   # Get short git hash from remote repo
-  GIT_HASH=$(git ls-remote git@github.com:OriginProtocol/$REPO.git HEAD | cut -c1-7)
+  GIT_HASH=$(git ls-remote git@github.com:OriginProtocol/$REPO.git ${BRANCH} | cut -c1-7)
   DEPLOY_TAG=${GIT_HASH}
 
   if [ "$DEPLOYED_TAG" == "$GIT_HASH" ]; then


### PR DESCRIPTION
Right now, the git hash that's part of the generated image tag is the
hash of HEAD, which is always master's HEAD. Changing it so that it uses
the HEAD for the appropriate branch.