### PR TITLE
Dont use wildcard allow origin

### DIFF
--- a/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://demo.{{.Release.Namespace }}.originprotocol.com"
 spec:
   tls:
     - secretName: bridge.{{ .Release.Namespace }}.originprotocol.com


### PR DESCRIPTION
The attestation XHR uses `credentials: 'include'` so we can't use a wildcard here. I'll have to handle this somehow for production because the domain won't be valid. This fixes it for now though.