### PR TITLE
Update ingress to point demo.originprotocol.com to current staging demo.originprotocol.com

### DIFF
--- a/deployment/kubernetes/charts/origin/templates/dapp.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/dapp.ingress.yaml
@@ -17,11 +17,20 @@ spec:
     - secretName: demo.{{ .Release.Namespace }}.originprotocol.com
       hosts:
         - demo.{{ .Release.Namespace }}.originprotocol.com
+    {{- if eq .Release.Namespace "staging" . }}
+    - secretName: demo.originprotocol.com
+      hosts:
+        - demo.originprotocol.com
+    {{- end }}
   rules:
   - host: demo.{{ .Release.Namespace }}.originprotocol.com
-    http:
+    http: &http_rules
       paths:
         - path: /
           backend:
             serviceName: {{ template "dapp.fullname" . }}
             servicePort: 80
+  {{- if eq .Release.Namespace "staging" . }}
+  - host: demo.originprotocol.com
+    http: *http_rules
+  {{- end  }}


### PR DESCRIPTION
Allows us to use `demo.originprotocol.com` for the current staging release.