### PR TITLE
Update CORS config for multiple domains

### DIFF
--- a/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
@@ -12,6 +12,8 @@ metadata:
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    # Disable CORS annotations because we have manually injected a snippet into
+    # the nginx configuration that this will overwrite
     # nginx.ingress.kubernetes.io/enable-cors: "true"
     # nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST"
     # nginx.ingress.kubernetes.io/cors-allow-origin: "https://demo.{{.Release.Namespace }}.originprotocol.com"

--- a/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
@@ -12,9 +12,9 @@ metadata:
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "https://demo.{{.Release.Namespace }}.originprotocol.com"
+    # nginx.ingress.kubernetes.io/enable-cors: "true"
+    # nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST"
+    # nginx.ingress.kubernetes.io/cors-allow-origin: "https://demo.{{.Release.Namespace }}.originprotocol.com"
 spec:
   tls:
     - secretName: bridge.{{ .Release.Namespace }}.originprotocol.com


### PR DESCRIPTION
We have started using `demo.originprotocol.com` and `demo.staging.originprotocol.com` for serving up the DApp. We can't specify multiple domains in the CORS allow origin header (limitation of CORS) and we have `credentials: 'include'` set on attestation requests so we can't use a wildcard. To work around this I had to manually inject some nginx config to set the allow origin header based on the incoming request domain. It's not included here because Helm won't know how to deal with it. I've commented out the CORS settings for now so my manual config doesn't get overwritten.

It's a bit of a hacky fix. I'll remove it when we move to our new `dapp.originprotocol.com` subdomain.