### PR TITLE
Proxy default faucet port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
     environment:
       - NODE_ENV=development
     ports:
+      - "5000:5000" # Faucet
       - "5002:5002"
       - "8080:8080"
       - "8081:8081" # Tests


### PR DESCRIPTION
Adding faucet server's default port 5000 to list of docker container proxied ports.