### PR TITLE
fix a problem with metamask 4.12.0

### DIFF
--- a/development/envfiles/origin-dapp.env
+++ b/development/envfiles/origin-dapp.env
@@ -6,7 +6,7 @@
 BRIDGE_SERVER_PROTOCOL=http
 BRIDGE_SERVER_DOMAIN=localhost:5000
 
-PROVIDER_URL=http://localhost:8545
+PROVIDER_URL=ws://localhost:8545
 
 # Discovery Server
 DISCOVERY_SERVER_URL=http://localhost:4000


### PR DESCRIPTION
`origin-js` crashes when creating a listing with Metamask 4.12.0. More details about the problem in this issue: https://github.com/OriginProtocol/origin-js/issues/587

